### PR TITLE
Convert app.js Router File to app.tsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "qg-frontend-v2",
       "version": "0.1.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
@@ -17,6 +18,7 @@
         "@types/node": "^16.11.1",
         "@types/react": "^17.0.30",
         "@types/react-dom": "^17.0.9",
+        "@types/react-router-dom": "^5.3.3",
         "bootstrap": "^5.1.1",
         "react": "^17.0.2",
         "react-bootstrap": "^1.6.4",
@@ -7298,6 +7300,11 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA=="
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -7629,6 +7636,25 @@
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.18.tgz",
+      "integrity": "sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@types/react-syntax-highlighter": {
@@ -34118,6 +34144,11 @@
         "@types/unist": "*"
       }
     },
+    "@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA=="
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -34420,6 +34451,25 @@
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.18.tgz",
+      "integrity": "sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==",
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/react-syntax-highlighter": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/node": "^16.11.1",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
+    "@types/react-router-dom": "^5.3.3",
     "bootstrap": "^5.1.1",
     "react": "^17.0.2",
     "react-bootstrap": "^1.6.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,17 @@
 import { BrowserRouter as Router, Route } from "react-router-dom";
 import Home from "./components/home/Home";
 import About from "./components/about/About";
-import Donate from "./components/donate/Donate.tsx";
-import Profile from "./components/profile/Profile.tsx";
-import Blog from "./components/blog/Blog.tsx";
-import AddResource from "./components/add-resource/AddResource.tsx";
-import Search from "./components/search/Search.tsx";
+import Donate from "./components/donate/Donate";
+import Profile from "./components/profile/Profile";
+import Blog from "./components/blog/Blog";
+import AddResource from "./components/add-resource/AddResource";
+import Search from "./components/search/Search";
 import Logout from "./components/logout/Logout";
-import GlobalStyles from "../src/Global.css";
+import GlobalStyles from "./Global.css";
 import TopNav from "./components/common/topnav/TopNav";
 
-const App = () => {
-	const windowWidth = window.innerWidth <= 375;
+const App = (): JSX.Element => {
+	const windowWidth = window.innerWidth <= 375; // TODO: Delete windowWidth; Moved to TopNav
 
 	return (
 		<>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3138,6 +3138,11 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/history@^4.7.11":
+  "integrity" "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA=="
+  "resolved" "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz"
+  "version" "4.7.11"
+
 "@types/hoist-non-react-statics@*":
   "integrity" "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA=="
   "resolved" "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz"
@@ -3304,6 +3309,23 @@
   "resolved" "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz"
   "version" "17.0.11"
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^5.3.3":
+  "integrity" "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw=="
+  "resolved" "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz"
+  "version" "5.3.3"
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  "integrity" "sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g=="
+  "resolved" "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.18.tgz"
+  "version" "5.1.18"
+  dependencies:
+    "@types/history" "^4.7.11"
     "@types/react" "*"
 
 "@types/react-syntax-highlighter@11.0.5":


### PR DESCRIPTION
Continuation of TypeScript conversion in #20  - Convert app.js Router File to app.tsx

Convert app.js to app.tsx, which needed the package @types/react-router-dom. This unfortunately depends on @types/history which is deprecated. [There is discussion about removing it](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58216) but as of now the package is still a dependency. @types/react-router-dom also [holds @types/react-router as a dependency](https://www.npmjs.com/package/@types/react-router-dom).

Please Slack me for anything! - Meke