### PR TITLE
Delete Unneeded windowWidth Prop From TopNav Component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ const App: React.FC = () => {
 		<>
 			<GlobalStyles />
 
-			<TopNav windowWidth={false} />
+			<TopNav />
 
 			<Router>
 				<Route path="/" exact component={Home} />

--- a/src/components/common/topnav/TopNav.tsx
+++ b/src/components/common/topnav/TopNav.tsx
@@ -9,7 +9,7 @@ import {
 } from "./TopNav.css";
 import icon from "../../../assets/topnav/QG-Logo-V3-White-Transparent-PNG-1.png";
 
-const TopNav: FC<{ windowWidth: boolean }> = () => {
+const TopNav: FC = () => {
 	const [width, setWidth] = useState(window.innerWidth);
 
 	const updateWidth = () => setWidth(window.innerWidth);


### PR DESCRIPTION
# Description
The TopNav component does not need the prop, and it’s making the app break when I run my local Contact work. This pull request’s work removes the boolean prop that tells the TopNav component whether the width is above or below 500px.

## Screen shots
From the local development environment run you can view the top navigation change:
Full width (where the window width is over 500px)
![](https://raw.githubusercontent.com/Githubbubber/images/main/qg_localDev_home_fullWidth.png)
Mobile (where the window width is under 500px)
![](https://raw.githubusercontent.com/Githubbubber/images/main/qg_localDev_home_mobile.png)

### From the QG Adobe XD mockups:
![](https://raw.githubusercontent.com/Githubbubber/images/main/qg_adobe_xd_home_fullWidth.png)
![](https://raw.githubusercontent.com/Githubbubber/images/main/qg_adobe_xd_home_mobile.png)
Note: The mobile mockup does not show the usual hamburger icon but it will be added, eventually, in the app. 

### Video:
[A video (to be DOWNLOADED) of the app behavior can be seen here](https://github.com/Githubbubber/images/blob/main/expected_behavior.mov)

## Changes done
- Delete the de-structured prop and its type from TopNav.tsx
- Delete the prop being passed through TopNav component within App.tsx

## Contact 
Contact on Slack: "Meke (Mickey) - She/her/cornball"