### PR TITLE
73 create bug issue template and eslint hook in actions

### DIFF
--- a/.github/issue_template/bug_report.yml
+++ b/.github/issue_template/bug_report.yml
@@ -1,0 +1,51 @@
+name: "\U0001F41E Bug report"
+description: Report an issue
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If you have any screenshots that you need to share in order to better prove your point here's where you can do it.
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide any links to repos or stackoverflow articles along with the steps you took leading to the bug. This helps the devs tremendously.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: 'Please include browser console and server logs around the time this bug occurred. Optional if provided reproduction. Please try not to insert an image but copy paste the log text.'
+      render: shell
+  - type: checkboxes
+    id: searched
+    attributes:
+      label: Have you checked if this issue has already been raised?
+      options:
+        - label: I did not find any similar issues
+          required: true
+  - type: checkboxes
+    id: CoC
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/CoHive-Software/ranch-social-booking-app/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/workflows/lint.txt
+++ b/.github/workflows/lint.txt
@@ -1,0 +1,18 @@
+name: ESLint on Push
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  eslint:
+    name: Run ESLint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Run ESLint
+        run: npm run lint

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,3 +31,6 @@ jobs:
     - run: npm run test:ci
       env:
         CI: ""
+
+    - name: Run ESLint
+      run: npm run lint


### PR DESCRIPTION
This PR 
resolves #38 
resolves #72 
resolves #73 

I pushed up 2 options for automating the Linter:
1. Append `npm run lint` to our preexisting [node.js.yml](https://github.com/QueerGlobal/qg-frontend-v2/blob/main/.github/workflows/node.js.yml)
2. Add separate lint action currently stored as `.github/workflows/lint.txt` (just convert to `lint.yml` in order to actualize)

I'm 90% sure the Bug template inside the new `.github/issue_template/bug.yml` will work but I need to end-test it with the GitHub UI to make sure everything is correct.

I will link areas of the code in comment below.