### PR TITLE
Contributing md branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+## Developer Git Workflow:
+
+- 📌 Clone down the organization's repo as your `origin`
+- 📌 Pick up a "ticket" from our [GitHub KanBan Board](https://github.com/orgs/QueerGlobal/projects/1/views/2) `Todo` lane
+  - 🐱‍🏍 Move the "ticket" into the `In Progress` lane
+  - 🏂 Click the title of the "ticket" and in the top right section make yourself an "Assignee"
+  - 💃 Click the title again for that ticket's _full_ view on GitHub
+  - 🏃‍♀️ Click "create a branch" directly on the right side under "development"
+  - 🏄‍♀️ Fetch from `origin main` in your IDE and checkout your new feature-branch which should share the same name as the issuing ticket
+- 📌 Use [Semantic Commit-Messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) for feature development
+- 📌 Push your feature-branch to the trunk remote `git push origin feature-branch`
+- 📌 PR to `main` branch for Code Review
+  - 🦹‍♀️ Move the "ticket" into the `In Review` lane
+  - 🕵️‍♂️ A member (non-author) of the team will review it soon
+  - 👨‍🚀 End to End testing will occur in during review
+- 🎇 Merge your (the author's) _approved_ PR branch to Staging or revise and repeat
+
+## Finding Work without Tickets
+
+- 📌 Please view our [Project Status](https://github.com/QueerGlobal/qg-frontend-v2#project-status) Header in the README for site content that is incomplete.
+
+## Creating an Issue
+
+- 📌 Visit the [GitHub Issues](https://github.com/QueerGlobal/qg-frontend-v2/issues) for our repo
+- 📌 Click "New Issue"
+- 🐛 For `Bug Reports` please select the appropriate Bug Report Issue Template
+  - 🐱‍👓 Follow the instructions when filling out the issue.
+  - 🐱‍🚀 Assign yourself to the issue and create a branch under the same name following the '🏃‍♀️ Click "create a branch"' steps in the above Developer Workflow...
+- 📌 For non-bug related Issues (solution proposal, project development, etc) use a blank issue
+  - 🐱‍🐉 Fill out to the best of your abilities.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Here's a rough list of Adobe XD views of the main routes:
 
 ---
 
+## Contributing
+
+- Please visit our [Contributing Documenation](https://github.com/QueerGlobal/qg-frontend-v2/blob/main/CONTRIBUTING.md) on how you can help out! ty!
+
+---
+
 ## Available Scripts
 
 In the project directory, you can run `npm start`
@@ -59,7 +65,7 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 Run `npm test` for info on [running tests](https://facebook.github.io/create-react-app/docs/running-tests)
 
-Run `npm run build` for info on [deployment](https://facebook.github.io/create-react-app/docs/deployment). 
+Run `npm run build` for info on [deployment](https://facebook.github.io/create-react-app/docs/deployment).
 
 ---
 


### PR DESCRIPTION
I went overboard in the contributing protocols, but I figured we can always cut parts down. 

- In this PR I am suggesting that hacktoberfest contributors make their `feature-branch` directly from an issue (sharing the same name) [see this line](https://github.com/QueerGlobal/qg-frontend-v2/pull/78/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R8)
  - We can omit this as it isn't currently part of our development workflow, however, if reduces the chances of devs working over each other 
  - Using tickets and the "in progress" lane also helps to minimize this.
- I also suggested using [Semantic Commit-Messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716), [here](https://github.com/QueerGlobal/qg-frontend-v2/pull/78/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R10) which is again, not part of our current workflow, however it helps if there is ever a call for `cherry picking` commits to have a consistent syntax for keyword reverse lookup in commit messages.

This is just the first draft so any part of this that you think is _extra_ or not needed I have no problem omitting😊 